### PR TITLE
Update ffmpeg.yml

### DIFF
--- a/.github/workflows/ffmpeg.yml
+++ b/.github/workflows/ffmpeg.yml
@@ -1,3 +1,5 @@
+name: ffmpeg
+
 on:
   push:
     paths:
@@ -5,19 +7,20 @@ on:
   schedule:
     - cron: '30 12 * * *'
 
-name: ffmpeg
 jobs:
   build:
     runs-on: ubuntu-20.04
+
     steps:
-      
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
       - name: Setup variables
         run: |
-          echo "FFMPEG=$(wget -qO- https://api.github.com/repos/BtbN/FFmpeg-Builds/tags | grep 'name' | cut -d\" -f4 | head -1)" >> $GITHUB_ENV
-          echo "VERSION=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
+          FFMPEG=$(wget -qO- https://api.github.com/repos/BtbN/FFmpeg-Builds/tags | grep 'name' | cut -d\" -f4 | head -1)
+          VERSION=$(date +%Y%m%d%H%M)
+          echo "FFMPEG=$FFMPEG" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
         shell: bash
         
       - name: Generate logs
@@ -42,7 +45,7 @@ jobs:
           # Build windows 64 bit GPL
           mkdir -p ffmpeg-windows
           pushd ffmpeg-windows || exit 1
-          wget -qO- https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/${{ env.FFMPEG }} | jq ".assets[] | {browser_download_url}" -c | jq .browser_download_url -r | grep -E ".ffmpeg-n.*.-gpl-[[:digit:]].[[:digit:]].zip" | sort -r | head -1 | wget -O ffmpeg-windows.zip -i -
+          wget -qO- "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/$FFMPEG" | jq ".assets[] | {browser_download_url}" -c | jq .browser_download_url -r | grep -E ".ffmpeg-n.*.-gpl-[[:digit:]].[[:digit:]].zip" | sort -r | head -1 | wget -O ffmpeg-windows.zip -i -
           unzip ffmpeg-windows.zip && rm -rfv ffmpeg-windows.zip
           mv ffmpeg-*/bin/*.exe .
           rm -rfv ffmpeg-*
@@ -51,7 +54,7 @@ jobs:
           # Build linux 64 bit GPL
           mkdir -p ffmpeg-linux
           pushd ffmpeg-linux || exit 1
-          wget -qO- https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/${{ env.FFMPEG }} | jq ".assets[] | {browser_download_url}" -c | jq .browser_download_url -r | grep -E ".ffmpeg-n.*.linux64-gpl-[[:digit:]].[[:digit:]].tar.xz" | sort -r | head -1 | wget -O ffmpeg-linux.tar.xz -i -
+          wget -qO- "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/$FFMPEG" | jq ".assets[] | {browser_download_url}" -c | jq .browser_download_url -r | grep -E ".ffmpeg-n.*.linux64-gpl-[[:digit:]].[[:digit:]].tar.xz" | sort -r | head -1 | wget -O ffmpeg-linux.tar.xz -i -
           tar -xJf ffmpeg-linux.tar.xz && rm -rfv ffmpeg-linux.tar.xz
           mv ffmpeg-*/bin/* .
           rm -rfv ffmpeg-*
@@ -77,14 +80,13 @@ jobs:
 
       - name: Release
         uses: ncipollo/release-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           name: FFmpeg
           tag: ${{ env.VERSION }}
           draft: false
           prerelease: false
-          artifacts: |
+          files: |
             ./release/*.zip
             
       - name: Delete Older Release


### PR DESCRIPTION
Removed the workflow name from the top-level "name" field since it is redundant.

Updated the "github-push-action" step to use the new "ad-m/github-push-action" repository.

Updated the "release-action" step to use the "ncipollo/release-action" repository and adjusted the input names accordingly.

Fixed the missing "token" input for the "release-action" step.

Removed unnecessary double quotes in the URLs used for API requests.

Adjusted the artifacts path for the "release-action" step to match the generated release files.